### PR TITLE
Refine matcher environment configuration

### DIFF
--- a/infra/pvm/.env.example
+++ b/infra/pvm/.env.example
@@ -28,16 +28,6 @@ MODEL_CACHE=./model_cache
 EMBED_MODEL=clip-vit-b32
 IMG_SIZE=(512,512)
 
-# Vector Search Configuration
-RETRIEVAL_TOPK=20
-
-# Matching Thresholds
-SIM_DEEP_MIN=0.82
-INLIERS_MIN=0.35
-MATCH_BEST_MIN=0.88
-MATCH_CONS_MIN=2
-MATCH_ACCEPT=0.80
-
 # Timezone
 TZ=Asia/Ho_Chi_Minh
 

--- a/libs/config.py
+++ b/libs/config.py
@@ -68,16 +68,6 @@ class Config:
     MODEL_CACHE: str = field(default_factory=lambda: get_env_var("MODEL_CACHE", "./model_cache"))
     IMG_SIZE: Tuple[int, int] = field(default_factory=lambda: get_env_tuple_int("IMG_SIZE", (512, 512)))
 
-    # Vector Search Configuration
-    RETRIEVAL_TOPK: int = field(default_factory=lambda: get_env_int("RETRIEVAL_TOPK", 20))
-    
-    # Matching Thresholds
-    SIM_DEEP_MIN: float = field(default_factory=lambda: get_env_float("SIM_DEEP_MIN", 0.82))
-    INLIERS_MIN: float = field(default_factory=lambda: get_env_float("INLIERS_MIN", 0.35))
-    MATCH_BEST_MIN: float = field(default_factory=lambda: get_env_float("MATCH_BEST_MIN", 0.88))
-    MATCH_CONS_MIN: int = field(default_factory=lambda: get_env_int("MATCH_CONS_MIN", 2))
-    MATCH_ACCEPT: float = field(default_factory=lambda: get_env_float("MATCH_ACCEPT", 0.80))
-    
     # Logging
     LOG_LEVEL: str = field(default_factory=lambda: get_env_var("LOG_LEVEL", "INFO"))
     

--- a/services/matcher/.env.example
+++ b/services/matcher/.env.example
@@ -1,0 +1,10 @@
+# Vector Search Configuration
+RETRIEVAL_TOPK=20
+
+# Matching Thresholds
+SIM_DEEP_MIN=0.82
+INLIERS_MIN=0.35
+MATCH_BEST_MIN=0.88
+MATCH_CONS_MIN=2
+MATCH_ACCEPT=0.80
+

--- a/services/matcher/config_loader.py
+++ b/services/matcher/config_loader.py
@@ -1,28 +1,28 @@
-"""
-Configuration loader for the matcher service.
-Uses environment variables directly since Docker Compose loads both shared and service-specific .env files.
-"""
+"""Configuration loader for the matcher service."""
+
 import os
 import sys
 from dataclasses import dataclass
 
 from dotenv import load_dotenv
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '.env'))
+
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env"))
 
 # Add libs directory to PYTHONPATH for imports
-sys.path.insert(0, '/app/libs')
+sys.path.insert(0, "/app/libs")
 
 try:
     from config import config as global_config
 except ImportError:
     # Fallback for local development
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    sys.path.append(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
     from libs.config import config as global_config
-
 @dataclass
 class MatcherConfig:
-    """Configuration for the matcher service"""
-    
+    """Configuration for the matcher service."""
+
     # Database configuration (from global config)
     POSTGRES_DSN: str = global_config.POSTGRES_DSN
     POSTGRES_USER: str = global_config.POSTGRES_USER
@@ -30,23 +30,23 @@ class MatcherConfig:
     POSTGRES_HOST: str = global_config.POSTGRES_HOST
     POSTGRES_PORT: str = os.getenv("POSTGRES_PORT", "5432")
     POSTGRES_DB: str = global_config.POSTGRES_DB
-    
+
     # Message broker configuration (from global config)
     BUS_BROKER: str = global_config.BUS_BROKER
-    
+
     # Data storage (from global config)
     DATA_ROOT: str = global_config.DATA_ROOT_CONTAINER
-    
-    # Matching parameters (from global config)
-    RETRIEVAL_TOPK: int = global_config.RETRIEVAL_TOPK
-    SIM_DEEP_MIN: float = global_config.SIM_DEEP_MIN
-    INLIERS_MIN: float = global_config.INLIERS_MIN
-    MATCH_BEST_MIN: float = global_config.MATCH_BEST_MIN
-    MATCH_CONS_MIN: int = global_config.MATCH_CONS_MIN
-    MATCH_ACCEPT: float = global_config.MATCH_ACCEPT
-    
+
+    # Matching parameters (from service environment)
+    RETRIEVAL_TOPK: int = int(os.getenv("RETRIEVAL_TOPK", 20))
+    SIM_DEEP_MIN: float = float(os.getenv("SIM_DEEP_MIN", 0.82))
+    INLIERS_MIN: float = float(os.getenv("INLIERS_MIN", 0.35))
+    MATCH_BEST_MIN: float = float(os.getenv("MATCH_BEST_MIN", 0.88))
+    MATCH_CONS_MIN: int = int(os.getenv("MATCH_CONS_MIN", 2))
+    MATCH_ACCEPT: float = float(os.getenv("MATCH_ACCEPT", 0.80))
+
     # Logging (from global config)
     LOG_LEVEL: str = global_config.LOG_LEVEL
 
-# Create config instance
+
 config = MatcherConfig()


### PR DESCRIPTION
## Summary
- remove matcher vector search and matching thresholds from the shared infra env and global config
- load the matcher thresholds from the service-specific environment and document defaults in a matcher `.env.example`
- simplify the matcher config loader by casting service environment values directly without redundant helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e4cd267483269acc58a1c20c025b