### PR TITLE
Add pytest-xdist and enable automatic test distribution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 asyncio_mode = auto
-addopts = --doctest-modules --strict-markers
+addopts = --doctest-modules --strict-markers -n auto
 env_override_existing_values = 1
 env_files =
     infra/pvm/.env

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # Testing dependencies
 pytest==7.4.3
+pytest-xdist==3.8.0
 pytest-asyncio==0.21.1
 httpx==0.25.2
 requests==2.31.0

--- a/services/main-api/pytest.ini
+++ b/services/main-api/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 pythonpath = . ../../libs/common-py
+addopts = -n auto
 env_override_existing_values = 1
 env_files =
     ../../infra/pvm/.env

--- a/services/video-crawler/pytest.ini
+++ b/services/video-crawler/pytest.ini
@@ -30,6 +30,7 @@ addopts =
     --strict-config
     --verbose
     -ra
+    -n auto
 
 # Ignore certain warnings
 filterwarnings =


### PR DESCRIPTION
## Summary
- add the pytest-xdist plugin to the shared testing requirements and pin it to version 3.8.0
- configure pytest to automatically distribute tests across CPU cores using pytest-xdist in the root and service-level pytest.ini files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e6ac12108326af6b9f31b7178380