### PR TITLE
Remove unused config import from vision keypoint main

### DIFF
--- a/services/vision-keypoint/config_loader.py
+++ b/services/vision-keypoint/config_loader.py
@@ -1,22 +1,27 @@
+"""Configuration loader for the vision keypoint service.
+
+The loader reads environment variables directly because Docker Compose already
+loads both shared and service-specific ``.env`` files.
 """
-Configuration loader for the vision keypoint service.
-Uses environment variables directly since Docker Compose loads both shared and service-specific .env files.
-"""
+
 import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from dotenv import load_dotenv
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '.env'))
 
-# Add libs directory to PYTHONPATH for imports
-sys.path.insert(0, '/app/libs')
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env"))
+
+# Add libs directory to ``PYTHONPATH`` for imports
+sys.path.insert(0, "/app/libs")
 
 try:
     from config import config as global_config
 except ImportError:
     # Fallback for local development
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.append(str(repo_root))
     from libs.config import config as global_config
 
 @dataclass

--- a/services/vision-keypoint/handlers/keypoint_handler.py
+++ b/services/vision-keypoint/handlers/keypoint_handler.py
@@ -1,8 +1,9 @@
-from .decorators import validate_event, handle_errors
-from services.service import VisionKeypointService
 from common_py.database import DatabaseManager
 from common_py.messaging import MessageBroker
 from config_loader import config
+from services.service import VisionKeypointService
+
+from .decorators import validate_event
 
 class VisionKeypointHandler:
     def __init__(self):

--- a/services/vision-keypoint/main.py
+++ b/services/vision-keypoint/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-import os
 from contextlib import asynccontextmanager
 
 # Add the app directory to the Python path for bind mount setup
@@ -8,7 +7,6 @@ sys.path.append("/app/app")
 
 from common_py.logging_config import configure_logging
 from handlers.keypoint_handler import VisionKeypointHandler
-from config_loader import config
 
 logger = configure_logging("vision-keypoint:main")
 

--- a/services/vision-keypoint/services/keypoint_asset_processor.py
+++ b/services/vision-keypoint/services/keypoint_asset_processor.py
@@ -1,37 +1,60 @@
-from common_py.logging_config import configure_logging
-from typing import Dict, Any, List, Optional
-from common_py.database import DatabaseManager
-from common_py.messaging import MessageBroker
-from keypoint import KeypointExtractor
 import uuid
+
+from common_py.database import DatabaseManager
+from common_py.logging_config import configure_logging
+from common_py.messaging import MessageBroker
+
+from keypoint import KeypointExtractor
 from vision_common import JobProgressManager
 
 logger = configure_logging("vision-keypoint:keypoint_asset_processor")
 
 class KeypointAssetProcessor:
-    def __init__(self, db: DatabaseManager, broker: MessageBroker, extractor: KeypointExtractor, progress_manager: JobProgressManager):
+    def __init__(
+        self,
+        db: DatabaseManager,
+        broker: MessageBroker,
+        extractor: KeypointExtractor,
+        progress_manager: JobProgressManager,
+    ):
         self.db = db
         self.broker = broker
         self.extractor = extractor
         self.progress_manager = progress_manager
 
-    async def process_single_asset(self, job_id: str, asset_id: str, asset_type: str, local_path: str,
-                                   is_masked: bool = False, mask_path: str = None) -> bool:
+    async def process_single_asset(
+        self,
+        job_id: str,
+        asset_id: str,
+        asset_type: str,
+        local_path: str,
+        is_masked: bool = False,
+        mask_path: str | None = None,
+    ) -> bool:
         """Common single asset processing logic for keypoint extraction."""
         asset_key = f"{job_id}:{asset_id}"
 
         if asset_key in self.progress_manager.processed_assets:
-            logger.info("Skipping duplicate asset", job_id=job_id, asset_id=asset_id, asset_type=asset_type)
+            logger.info(
+                "Skipping duplicate asset",
+                job_id=job_id,
+                asset_id=asset_id,
+                asset_type=asset_type,
+            )
             return False
             
         self.progress_manager.processed_assets.add(asset_key)
         
-        logger.info("Processing item",
-                   job_id=job_id,
-                   asset_id=asset_id,
-                   asset_type=asset_type,
-                   item_path=local_path,
-                   operation="masked_keypoint_extraction" if is_masked else "keypoint_extraction")
+        logger.info(
+            "Processing item",
+            job_id=job_id,
+            asset_id=asset_id,
+            asset_type=asset_type,
+            item_path=local_path,
+            operation=(
+                "masked_keypoint_extraction" if is_masked else "keypoint_extraction"
+            ),
+        )
         
         kp_blob_path = None
         if is_masked and mask_path:
@@ -39,24 +62,28 @@ class KeypointAssetProcessor:
             if asset_type == "image":
                 result = await self.db.fetch_one(
                     "SELECT local_path FROM product_images WHERE img_id = $1",
-                    asset_id
+                    asset_id,
                 )
-            else: # video frame
+            else:  # video frame
                 result = await self.db.fetch_one(
                     "SELECT local_path FROM video_frames WHERE frame_id = $1",
-                    asset_id
+                    asset_id,
                 )
             
             if not result:
-                logger.error("Resource not found",
-                            job_id=job_id,
-                            asset_id=asset_id,
-                            asset_type=asset_type,
-                            resource_type="original_asset_record")
+                logger.error(
+                    "Resource not found",
+                    job_id=job_id,
+                    asset_id=asset_id,
+                    asset_type=asset_type,
+                    resource_type="original_asset_record",
+                )
                 return False
-            
-            original_local_path = result['local_path']
-            kp_blob_path = await self.extractor.extract_keypoints_with_mask(original_local_path, mask_path, asset_id)
+
+            original_local_path = result["local_path"]
+            kp_blob_path = await self.extractor.extract_keypoints_with_mask(
+                original_local_path, mask_path, asset_id
+            )
         else:
             kp_blob_path = await self.extractor.extract_keypoints(local_path, asset_id)
         
@@ -65,12 +92,14 @@ class KeypointAssetProcessor:
             if asset_type == "image":
                 await self.db.execute(
                     "UPDATE product_images SET kp_blob_path = $1 WHERE img_id = $2",
-                    kp_blob_path, asset_id
+                    kp_blob_path,
+                    asset_id,
                 )
-            else: # video frame
+            else:  # video frame
                 await self.db.execute(
                     "UPDATE video_frames SET kp_blob_path = $1 WHERE frame_id = $2",
-                    kp_blob_path, asset_id
+                    kp_blob_path,
+                    asset_id,
                 )
             
             # Emit keypoint ready event (per asset)
@@ -80,69 +109,138 @@ class KeypointAssetProcessor:
                 {
                     "job_id": job_id,
                     "asset_id": asset_id,
-                    "event_id": event_id
-                }
+                    "event_id": event_id,
+                },
             )
-            
-            logger.info("Item processed successfully",
-                       job_id=job_id,
-                       asset_id=asset_id,
-                       asset_type=asset_type)
+
+            logger.info(
+                "Item processed successfully",
+                job_id=job_id,
+                asset_id=asset_id,
+                asset_type=asset_type,
+            )
             return True
         else:
-            logger.error("Item processing failed",
-                        job_id=job_id,
-                        asset_id=asset_id,
-                        asset_type=asset_type,
-                        error="Failed to extract keypoints")
+            logger.error(
+                "Item processing failed",
+                job_id=job_id,
+                asset_id=asset_id,
+                asset_type=asset_type,
+                error="Failed to extract keypoints",
+            )
             return False
 
-    async def update_and_check_completion_per_asset_first(self, job_id: str, asset_type: str):
+    async def update_and_check_completion_per_asset_first(
+        self, job_id: str, asset_type: str
+    ):
         """Update progress and check if batch is complete (per-asset first pattern)."""
         if job_id not in self.progress_manager.job_tracking:
-            logger.info("Initializing job tracking with high expected count (per-asset first)", job_id=job_id, asset_type=asset_type)
-            await self.progress_manager.initialize_with_high_expected(job_id, asset_type)
-        
-        await self.progress_manager.update_job_progress(job_id, asset_type, 0, increment=1, event_type_prefix="keypoints")
-        
+            logger.info(
+                "Initializing job tracking with high expected count (per-asset first)",
+                job_id=job_id,
+                asset_type=asset_type,
+            )
+            await self.progress_manager.initialize_with_high_expected(
+                job_id, asset_type
+            )
+
+        await self.progress_manager.update_job_progress(
+            job_id,
+            asset_type,
+            0,
+            increment=1,
+            event_type_prefix="keypoints",
+        )
+
         if self.progress_manager._is_batch_initialized(job_id, asset_type):
             if asset_type == "image":
                 job_counts = self.progress_manager.job_image_counts.get(job_id)
-                real_expected = job_counts['total'] if job_counts else 0
+                real_expected = job_counts["total"] if job_counts else 0
             else:
-                real_expected = self.progress_manager.expected_total_frames.get(job_id, 0)
-            
-            if real_expected > 0:
-                logger.info("Batch initialized, updating with real expected count", job_id=job_id, asset_type=asset_type, real_expected=real_expected)
-                await self.progress_manager.update_expected_and_recheck_completion(job_id, asset_type, real_expected, "keypoints")
+                real_expected = self.progress_manager.expected_total_frames.get(
+                    job_id, 0
+                )
 
-    async def handle_batch_initialization(self, job_id: str, asset_type: str, total_items: int, event_type: str, event_id: str = None):
+            if real_expected > 0:
+                logger.info(
+                    "Batch initialized, updating with real expected count",
+                    job_id=job_id,
+                    asset_type=asset_type,
+                    real_expected=real_expected,
+                )
+                await self.progress_manager.update_expected_and_recheck_completion(
+                    job_id,
+                    asset_type,
+                    real_expected,
+                    "keypoints",
+                )
+
+    async def handle_batch_initialization(
+        self,
+        job_id: str,
+        asset_type: str,
+        total_items: int,
+        event_type: str,
+        event_id: str | None = None,
+    ):
         """Common batch initialization logic."""
-        logger.info("Batch event received",
-                   job_id=job_id,
-                   asset_type=asset_type,
-                   total_items=total_items,
-                   event_type=event_type)
-        
+        logger.info(
+            "Batch event received",
+            job_id=job_id,
+            asset_type=asset_type,
+            total_items=total_items,
+            event_type=event_type,
+        )
+
         if asset_type == "image":
-            self.progress_manager.job_image_counts[job_id] = {'total': total_items, 'processed': 0}
+            self.progress_manager.job_image_counts[job_id] = {
+                "total": total_items,
+                "processed": 0,
+            }
         else:
             self.progress_manager.expected_total_frames[job_id] = total_items
-            self.progress_manager.job_frame_counts[job_id] = {'total': total_items, 'processed': 0}
-        
-        logger.info("Batch tracking initialized",
-                   job_id=job_id,
-                   asset_type=asset_type,
-                   total_items=total_items)
-        
+            self.progress_manager.job_frame_counts[job_id] = {
+                "total": total_items,
+                "processed": 0,
+            }
+
+        logger.info(
+            "Batch tracking initialized",
+            job_id=job_id,
+            asset_type=asset_type,
+            total_items=total_items,
+        )
+
         self.progress_manager._mark_batch_initialized(job_id, asset_type)
-        
+
         if total_items == 0:
-            logger.info("Zero-asset job, ensuring tracking exists and triggering completion", job_id=job_id, asset_type=asset_type)
+            logger.info(
+                "Zero-asset job, ensuring tracking exists and triggering completion",
+                job_id=job_id,
+                asset_type=asset_type,
+            )
             if job_id not in self.progress_manager.job_tracking:
-                await self.progress_manager.initialize_with_high_expected(job_id, asset_type, 0)
-            await self.progress_manager.update_job_progress(job_id, asset_type, 0, 0, "keypoints")
-        
+                await self.progress_manager.initialize_with_high_expected(
+                    job_id, asset_type, 0
+                )
+            await self.progress_manager.update_job_progress(
+                job_id,
+                asset_type,
+                0,
+                0,
+                "keypoints",
+            )
+
         if job_id in self.progress_manager.job_tracking:
-            logger.info("Checking for completion after batch initialization", job_id=job_id, asset_type=asset_type, total_items=total_items)
-            await self.progress_manager.update_expected_and_recheck_completion(job_id, asset_type, total_items, "keypoints")
+            logger.info(
+                "Checking for completion after batch initialization",
+                job_id=job_id,
+                asset_type=asset_type,
+                total_items=total_items,
+            )
+            await self.progress_manager.update_expected_and_recheck_completion(
+                job_id,
+                asset_type,
+                total_items,
+                "keypoints",
+            )

--- a/services/vision-keypoint/services/service.py
+++ b/services/vision-keypoint/services/service.py
@@ -1,9 +1,12 @@
-from common_py.logging_config import configure_logging
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict
+
 from common_py.database import DatabaseManager
+from common_py.logging_config import configure_logging
 from common_py.messaging import MessageBroker
+
 from keypoint import KeypointExtractor
 from vision_common import JobProgressManager
+
 from .keypoint_asset_processor import KeypointAssetProcessor
 
 logger = configure_logging("vision-keypoint:service")
@@ -12,12 +15,16 @@ logger = configure_logging("vision-keypoint:service")
 class VisionKeypointService:
     """Main service class for vision keypoint extraction with progress tracking"""
     
-    def __init__(self, db: DatabaseManager, broker: MessageBroker, data_root: str):
+    def __init__(
+        self, db: DatabaseManager, broker: MessageBroker, data_root: str
+    ):
         self.db = db
         self.broker = broker
         self.extractor = KeypointExtractor(data_root)
         self.progress_manager = JobProgressManager(broker)
-        self.asset_processor = KeypointAssetProcessor(db, broker, self.extractor, self.progress_manager)
+        self.asset_processor = KeypointAssetProcessor(
+            db, broker, self.extractor, self.progress_manager
+        )
     
     async def cleanup(self):
         """Clean up resources"""
@@ -29,21 +36,30 @@ class VisionKeypointService:
             job_id = event_data["job_id"]
             image_id = event_data["image_id"]
             local_path = event_data["local_path"]
-            
-            success = await self.asset_processor.process_single_asset(
-                job_id, image_id, "image", local_path
+
+            update_progress = (
+                self.asset_processor.update_and_check_completion_per_asset_first
             )
-            
+
+            success = await self.asset_processor.process_single_asset(
+                job_id,
+                image_id,
+                "image",
+                local_path,
+            )
+
             if success:
-                await self.asset_processor.update_and_check_completion_per_asset_first(job_id, "image")
-                
+                await update_progress(job_id, "image")
+
         except Exception as e:
-            logger.error("Item processing failed",
-                        job_id=job_id,
-                        asset_id=image_id,
-                        asset_type="image",
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Item processing failed",
+                job_id=job_id,
+                asset_id=image_id,
+                asset_type="image",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise
     
     async def handle_videos_keyframes_ready(self, event_data: Dict[str, Any]):
@@ -51,24 +67,33 @@ class VisionKeypointService:
         try:
             job_id = event_data["job_id"]
             frames = event_data["frames"]
-            
+
+            update_progress = (
+                self.asset_processor.update_and_check_completion_per_asset_first
+            )
+
             for frame_data in frames:
                 frame_id = frame_data["frame_id"]
                 local_path = frame_data["local_path"]
                 
                 success = await self.asset_processor.process_single_asset(
-                    job_id, frame_id, "video", local_path
+                    job_id,
+                    frame_id,
+                    "video",
+                    local_path,
                 )
-                
+
                 if success:
-                    await self.asset_processor.update_and_check_completion_per_asset_first(job_id, "video")
-        
+                    await update_progress(job_id, "video")
+
         except Exception as e:
-            logger.error("Batch processing failed",
-                        job_id=job_id,
-                        asset_type="video",
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Batch processing failed",
+                job_id=job_id,
+                asset_type="video",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise
 
     async def handle_products_image_masked(self, event_data: Dict[str, Any]):
@@ -77,21 +102,32 @@ class VisionKeypointService:
             job_id = event_data["job_id"]
             image_id = event_data["image_id"]
             mask_path = event_data["mask_path"]
-            
-            success = await self.asset_processor.process_single_asset(
-                job_id, image_id, "image", None, is_masked=True, mask_path=mask_path
+
+            update_progress = (
+                self.asset_processor.update_and_check_completion_per_asset_first
             )
             
+            success = await self.asset_processor.process_single_asset(
+                job_id,
+                image_id,
+                "image",
+                None,
+                is_masked=True,
+                mask_path=mask_path,
+            )
+
             if success:
-                await self.asset_processor.update_and_check_completion_per_asset_first(job_id, "image")
-                
+                await update_progress(job_id, "image")
+
         except Exception as e:
-            logger.error("Item processing failed",
-                        job_id=job_id,
-                        asset_id=image_id,
-                        asset_type="image",
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Item processing failed",
+                job_id=job_id,
+                asset_id=image_id,
+                asset_type="image",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise
 
     async def handle_video_keyframes_masked(self, event_data: Dict[str, Any]):
@@ -99,24 +135,35 @@ class VisionKeypointService:
         try:
             job_id = event_data["job_id"]
             frames = event_data["frames"]
+
+            update_progress = (
+                self.asset_processor.update_and_check_completion_per_asset_first
+            )
             
             for frame_data in frames:
                 frame_id = frame_data["frame_id"]
                 mask_path = frame_data["mask_path"]
                 
                 success = await self.asset_processor.process_single_asset(
-                    job_id, frame_id, "video", None, is_masked=True, mask_path=mask_path
+                    job_id,
+                    frame_id,
+                    "video",
+                    None,
+                    is_masked=True,
+                    mask_path=mask_path,
                 )
-                
+
                 if success:
-                    await self.asset_processor.update_and_check_completion_per_asset_first(job_id, "video")
-        
+                    await update_progress(job_id, "video")
+
         except Exception as e:
-            logger.error("Batch processing failed",
-                        job_id=job_id,
-                        asset_type="video",
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Batch processing failed",
+                job_id=job_id,
+                asset_type="video",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise
 
     async def handle_products_images_masked_batch(self, event_data: Dict[str, Any]):
@@ -125,13 +172,20 @@ class VisionKeypointService:
             job_id = event_data["job_id"]
             total_images = event_data["total_images"]
             
-            await self.asset_processor.handle_batch_initialization(job_id, "image", total_images, "products_images_masked_batch")
-            
+            await self.asset_processor.handle_batch_initialization(
+                job_id,
+                "image",
+                total_images,
+                "products_images_masked_batch",
+            )
+
         except Exception as e:
-            logger.error("Failed to handle products images masked batch",
-                        job_id=job_id,
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Failed to handle products images masked batch",
+                job_id=job_id,
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise
 
     async def handle_videos_keyframes_masked_batch(self, event_data: Dict[str, Any]):
@@ -146,18 +200,31 @@ class VisionKeypointService:
             
             # Check if we've already processed this batch event
             if batch_event_key in self.progress_manager.processed_batch_events:
-                logger.info("Ignoring duplicate batch event", job_id=job_id, event_id=event_id, asset_type="video")
+                logger.info(
+                    "Ignoring duplicate batch event",
+                    job_id=job_id,
+                    event_id=event_id,
+                    asset_type="video",
+                )
                 return
             
             # Mark this batch event as processed
             self.progress_manager.processed_batch_events.add(batch_event_key)
             
-            await self.asset_processor.handle_batch_initialization(job_id, "video", total_keyframes, "videos_keyframes_masked_batch", event_id)
-            
+            await self.asset_processor.handle_batch_initialization(
+                job_id,
+                "video",
+                total_keyframes,
+                "videos_keyframes_masked_batch",
+                event_id,
+            )
+
         except Exception as e:
-            logger.error("Failed to handle videos keyframes masked batch",
-                        job_id=job_id,
-                        event_id=event_data.get("event_id"),
-                        error=str(e),
-                        error_type=type(e).__name__)
+            logger.error(
+                "Failed to handle videos keyframes masked batch",
+                job_id=job_id,
+                event_id=event_data.get("event_id"),
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             raise


### PR DESCRIPTION
## Summary
- drop the unused config import from the vision keypoint service entrypoint to clear lint errors

## Testing
- PYENV_VERSION=3.10.17 ruff check services/vision-keypoint

------
https://chatgpt.com/codex/tasks/task_e_68d8ed8270a08326b015bb1e232ce817