### PR TITLE
fix: make video crawler lint clean

### DIFF
--- a/services/video-crawler/fetcher/video_fetcher.py
+++ b/services/video-crawler/fetcher/video_fetcher.py
@@ -3,7 +3,6 @@ import time
 from typing import List, Dict, Any, Optional
 from platform_crawler.interface import PlatformCrawlerInterface
 from common_py.logging_config import configure_logging
-from config_loader import config
 
 logger = configure_logging("video-crawler:video_fetcher")
 

--- a/services/video-crawler/handlers/event_emitter.py
+++ b/services/video-crawler/handlers/event_emitter.py
@@ -1,7 +1,8 @@
 import uuid
-from typing import Dict, Any, Optional
-from common_py.messaging import MessageBroker
+from typing import Optional
+
 from common_py.logging_config import configure_logging
+from common_py.messaging import MessageBroker
 
 logger = configure_logging("video-crawler:event_emitter")
 

--- a/services/video-crawler/keyframe_extractor/abstract_extractor.py
+++ b/services/video-crawler/keyframe_extractor/abstract_extractor.py
@@ -5,10 +5,13 @@ This module provides a common implementation foundation for all keyframe extract
 including shared utilities, logging, and common validation logic.
 """
 
+from __future__ import annotations
+
 import shutil
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
 import cv2
 import numpy as np
 from common_py.logging_config import configure_logging
@@ -16,6 +19,10 @@ from config_loader import config
 from .interface import KeyframeExtractorInterface
 
 logger = configure_logging("video-crawler:abstract_extractor")
+
+
+if TYPE_CHECKING:
+    from models.video import VideoProperties
 
 
 class AbstractKeyframeExtractor(KeyframeExtractorInterface, ABC):
@@ -258,7 +265,7 @@ class AbstractKeyframeExtractor(KeyframeExtractorInterface, ABC):
             logger.error("Failed to calculate blur score", error=str(e))
             return 0.0
     
-    def _get_video_properties(self, cap: cv2.VideoCapture, video_id: str) -> 'VideoProperties':
+    def _get_video_properties(self, cap: cv2.VideoCapture, video_id: str) -> VideoProperties:
         """
         Extract video properties from OpenCV VideoCapture object.
         

--- a/services/video-crawler/keyframe_extractor/length_adaptive_extractor.py
+++ b/services/video-crawler/keyframe_extractor/length_adaptive_extractor.py
@@ -5,12 +5,10 @@ This module provides a concrete implementation of keyframe extraction that adapt
 the number and timing of extracted frames based on video duration.
 """
 
-import asyncio
 from pathlib import Path
 from typing import List, Tuple, Optional
 from dataclasses import dataclass
 import cv2
-import numpy as np
 from common_py.logging_config import configure_logging
 from .abstract_extractor import AbstractKeyframeExtractor
 

--- a/services/video-crawler/main.py
+++ b/services/video-crawler/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-import os
 from contextlib import asynccontextmanager
 
 # Add the app directory to the Python path for bind mount setup
@@ -37,7 +36,7 @@ async def main():
             )
             
             logger.info("Video crawler service started")
-            
+
             # Keep service running
             while True:
                 await asyncio.sleep(1)

--- a/services/video-crawler/platform_crawler/mock_crawler.py
+++ b/services/video-crawler/platform_crawler/mock_crawler.py
@@ -1,8 +1,7 @@
 import os
-from typing import List, Dict, Any
 from pathlib import Path
-import asyncio
-from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
 from platform_crawler.interface import PlatformCrawlerInterface
 
 

--- a/services/video-crawler/platform_crawler/tiktok/tiktok_crawler.py
+++ b/services/video-crawler/platform_crawler/tiktok/tiktok_crawler.py
@@ -1,12 +1,12 @@
 """TikTok video crawler implementation."""
-import os
+
 import asyncio
-from typing import List, Dict, Any
 from pathlib import Path
+from typing import Any, Dict, List
+
 from common_py.logging_config import configure_logging
 from platform_crawler.interface import PlatformCrawlerInterface
 from platform_crawler.tiktok.tiktok_searcher import TikTokSearcher
-from config_loader import config
 
 logger = configure_logging("video-crawler:tiktok_crawler")
 

--- a/services/video-crawler/platform_crawler/tiktok/tiktok_models.py
+++ b/services/video-crawler/platform_crawler/tiktok/tiktok_models.py
@@ -1,7 +1,6 @@
 """TikTok data models for video metadata."""
-from typing import Optional
+
 from dataclasses import dataclass
-from datetime import datetime
 
 
 @dataclass

--- a/services/video-crawler/platform_crawler/tiktok/tiktok_searcher.py
+++ b/services/video-crawler/platform_crawler/tiktok/tiktok_searcher.py
@@ -1,7 +1,9 @@
 """TikTok HTTP client for searching videos via external API."""
+
 import asyncio
+
 import httpx
-from typing import List, Dict, Any, Optional
+
 from common_py.logging_config import configure_logging
 from config_loader import config
 from .tiktok_models import TikTokSearchResponse

--- a/services/video-crawler/platform_crawler/youtube/downloader/__init__.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/__init__.py
@@ -1,6 +1,5 @@
-"""
-YouTube Downloader Package
-"""
-from .downloader import YoutubeDownloader
+"""YouTube Downloader package exports."""
 
-__all__ = ['YoutubeDownloader']
+from .downloader import YoutubeDownloader  # noqa: F401
+
+__all__ = ["YoutubeDownloader"]

--- a/services/video-crawler/platform_crawler/youtube/downloader/config.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/config.py
@@ -1,5 +1,5 @@
 import random
-import os
+
 from config_loader import config
 
 class DownloaderConfig:

--- a/services/video-crawler/platform_crawler/youtube/downloader/downloader.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/downloader.py
@@ -257,7 +257,7 @@ class YoutubeDownloader:
             download_dir: Directory where videos are stored
         """
         try:
-            logger.info(f"[CLEANUP-AFTER-DOWNLOAD] Starting cleanup after successful download")
+            logger.info("[CLEANUP-AFTER-DOWNLOAD] Starting cleanup after successful download")
             
             # Perform cleanup with dry_run=False to actually remove files
             cleanup_results = await cleanup_service.perform_cleanup(download_dir, dry_run=False)
@@ -268,7 +268,7 @@ class YoutubeDownloader:
                     f"[CLEANUP-AFTER-DOWNLOAD-COMPLETE] Removed {len(cleanup_results['files_removed'])} files, freed {freed_mb:.2f}MB"
                 )
             else:
-                logger.info(f"[CLEANUP-AFTER-DOWNLOAD] No old files to remove")
+                logger.info("[CLEANUP-AFTER-DOWNLOAD] No old files to remove")
                 
         except Exception as e:
             logger.error(f"[CLEANUP-AFTER-DOWNLOAD-ERROR] Failed to perform cleanup: {str(e)}")

--- a/services/video-crawler/platform_crawler/youtube/downloader/error_handler.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/error_handler.py
@@ -1,6 +1,5 @@
-import asyncio
 import yt_dlp
-from typing import Dict, Any
+
 from common_py.logging_config import configure_logging
 
 logger = configure_logging("video-crawler:error_handler")

--- a/services/video-crawler/platform_crawler/youtube/downloader/file_manager.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/file_manager.py
@@ -1,9 +1,8 @@
 import os
 import time
 from pathlib import Path
-from typing import Dict, Any, List
+
 from common_py.logging_config import configure_logging
-from platform_crawler.youtube.youtube_utils import sanitize_filename
 
 logger = configure_logging("video-crawler:file_manager")
 

--- a/services/video-crawler/platform_crawler/youtube/downloader/retry_handler.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/retry_handler.py
@@ -1,6 +1,6 @@
 import asyncio
-import time
-from typing import Dict, Any
+from typing import Any, Dict
+
 from common_py.logging_config import configure_logging
 
 logger = configure_logging("video-crawler:retry_handler")

--- a/services/video-crawler/platform_crawler/youtube/downloader/ytdlp_config.py
+++ b/services/video-crawler/platform_crawler/youtube/downloader/ytdlp_config.py
@@ -1,6 +1,4 @@
-import random
-from typing import Dict, Any
-from .config import DownloaderConfig
+from typing import Any, Dict
 
 class YTDLPOptionsBuilder:
     """Builds yt-dlp options for video downloads"""

--- a/services/video-crawler/platform_crawler/youtube/youtube_crawler.py
+++ b/services/video-crawler/platform_crawler/youtube/youtube_crawler.py
@@ -1,16 +1,14 @@
-import os
-import re
 import asyncio
 import random
-from typing import List, Dict, Any, Callable, Protocol
 from pathlib import Path
-from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
 from common_py.logging_config import configure_logging
-from platform_crawler.interface import PlatformCrawlerInterface
-from platform_crawler.youtube.youtube_searcher import YoutubeSearcher
-from platform_crawler.youtube.downloader import YoutubeDownloader
-from platform_crawler.youtube.youtube_utils import is_url_like, sanitize_filename
 from config_loader import config
+from platform_crawler.interface import PlatformCrawlerInterface
+from platform_crawler.youtube.downloader import YoutubeDownloader
+from platform_crawler.youtube.youtube_searcher import YoutubeSearcher
+from platform_crawler.youtube.youtube_utils import is_url_like
 
 logger = configure_logging("video-crawler:youtube_crawler")
 

--- a/services/video-crawler/platform_crawler/youtube/youtube_searcher.py
+++ b/services/video-crawler/platform_crawler/youtube/youtube_searcher.py
@@ -1,15 +1,16 @@
-import re
 import asyncio
-from typing import List, Dict, Any
 from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
 import yt_dlp
+
 from common_py.logging_config import configure_logging
-from ..utils.filter_chain import FilterChain
+from config_loader import config
 from platform_crawler.youtube.youtube_filters import (
+    filter_duration,
     filter_valid_entry,
-    filter_duration
 )
-from config_loader import config # Import config
+from ..utils.filter_chain import FilterChain
 
 logger = configure_logging("video-crawler:youtube_searcher", log_level=config.LOG_LEVEL)
 
@@ -58,11 +59,11 @@ class YoutubeSearcher:
                 # Add specific handling for common errors
                 error_msg = str(e).lower()
                 if "403" in error_msg or "forbidden" in error_msg:
-                    logger.warning(f"Received 403 Forbidden error. This may be due to rate limiting. Waiting before next attempt.")
+                    logger.warning("Received 403 Forbidden error. This may be due to rate limiting. Waiting before next attempt.")
                     if attempts < MAX_ATTEMPTS:
                         await asyncio.sleep(10)  # Wait longer for 403 errors
                 elif "429" in error_msg or "too many requests" in error_msg:
-                    logger.warning(f"Received 429 Too Many Requests error. Waiting before next attempt.")
+                    logger.warning("Received 429 Too Many Requests error. Waiting before next attempt.")
                     if attempts < MAX_ATTEMPTS:
                         await asyncio.sleep(15)  # Wait even longer for rate limiting
                 break

--- a/services/video-crawler/services/cleanup_service.py
+++ b/services/video-crawler/services/cleanup_service.py
@@ -2,11 +2,11 @@
 Video cleanup service for automatically removing old video files.
 """
 
-import asyncio
-from typing import Dict, Any, List
+from typing import Any, Dict
+
 from common_py.logging_config import configure_logging
-from utils.file_cleanup import VideoCleanupManager
 from config_loader import config
+from utils.file_cleanup import VideoCleanupManager
 
 logger = configure_logging("video-crawler:cleanup_service")
 

--- a/services/video-crawler/services/service.py
+++ b/services/video-crawler/services/service.py
@@ -13,7 +13,6 @@ from platform_crawler.mock_crawler import MockPlatformCrawler
 from platform_crawler.youtube.youtube_crawler import YoutubeCrawler
 from platform_crawler.tiktok.tiktok_crawler import TikTokCrawler
 from handlers.event_emitter import EventEmitter
-from utils.file_cleanup import VideoCleanupManager
 from services.cleanup_service import cleanup_service
 from common_py.logging_config import configure_logging
 from config_loader import config

--- a/services/video-crawler/tests/conftest.py
+++ b/services/video-crawler/tests/conftest.py
@@ -1,11 +1,12 @@
 """
 Pytest configuration and shared fixtures for video-crawler tests
 """
-import pytest
-import tempfile
 import asyncio
+import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
+
+import pytest
 
 # Ensure common_py is in the path for tests
 import sys

--- a/services/video-crawler/tests/contract/test_tiktok_api.py
+++ b/services/video-crawler/tests/contract/test_tiktok_api.py
@@ -1,10 +1,13 @@
 """Contract tests for TikTok Search API integration."""
-import pytest
-pytestmark = pytest.mark.contract
+
 import httpx
+import pytest
 from unittest.mock import AsyncMock, patch
 
 from config_loader import config
+
+
+pytestmark = pytest.mark.contract
 
 
 class TestTikTokAPIContract:

--- a/services/video-crawler/tests/integration/test_cleanup_integration.py
+++ b/services/video-crawler/tests/integration/test_cleanup_integration.py
@@ -1,20 +1,20 @@
-"""
-Integration tests for video cleanup workflow
-"""
+"""Integration tests for video cleanup workflow."""
 
-import pytest
-pytestmark = pytest.mark.integration
+import asyncio
 import os
 import tempfile
 import unittest
-import asyncio
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch
 
-from services.service import VideoCrawlerService
-from services.cleanup_service import VideoCleanupService
+import pytest
+
 from config_loader import config
+from services.cleanup_service import VideoCleanupService
+
+
+pytestmark = pytest.mark.integration
 
 
 class TestCleanupIntegration(unittest.TestCase):
@@ -318,7 +318,7 @@ class TestCleanupIntegration(unittest.TestCase):
                     
                 # Should work with different retention periods
                 self.assertIsInstance(info, dict, f"Should return info for {retention} day retention")
-                self.assertEqual(info['retention_days'], retention, f"Should have correct retention days")
+                self.assertEqual(info['retention_days'], retention, "Should have correct retention days")
 
 
 

--- a/services/video-crawler/tests/integration/test_integration.py
+++ b/services/video-crawler/tests/integration/test_integration.py
@@ -1,19 +1,19 @@
-import pytest
-pytestmark = pytest.mark.integration
 import asyncio
-import tempfile
 import os
-from pathlib import Path
-from unittest.mock import MagicMock, patch, AsyncMock
+import tempfile
+from unittest.mock import AsyncMock, MagicMock
 
-# Import the modules to test
-from services.service import VideoCrawlerService
+import pytest
+
 from fetcher.video_fetcher import VideoFetcher
 from platform_crawler.interface import PlatformCrawlerInterface
 from platform_crawler.mock_crawler import MockPlatformCrawler
+from services.service import VideoCrawlerService
+
+
+pytestmark = pytest.mark.integration
 
 # Mock VideoFrameCRUD since it's external dependency
-from unittest.mock import MagicMock
 VideoFrameCRUD = MagicMock
 
 
@@ -119,13 +119,19 @@ class TestVideoCrawlerIntegration:
         assert video_crawler_service.event_emitter.broker.publish_event.called
         
         # Check that batch keyframes ready event was published
-        batch_calls = [call for call in video_crawler_service.event_emitter.broker.publish_event.call_args_list
-                      if call[0][0] == "videos.keyframes.ready.batch"]
+        batch_calls = [
+            event_call
+            for event_call in video_crawler_service.event_emitter.broker.publish_event.call_args_list
+            if event_call[0][0] == "videos.keyframes.ready.batch"
+        ]
         assert len(batch_calls) > 0, "Batch keyframes ready event should be published"
         
         # Check that videos collections completed event was published
-        collection_calls = [call for call in video_crawler_service.event_emitter.broker.publish_event.call_args_list
-                           if call[0][0] == "videos.collections.completed"]
+        collection_calls = [
+            event_call
+            for event_call in video_crawler_service.event_emitter.broker.publish_event.call_args_list
+            if event_call[0][0] == "videos.collections.completed"
+        ]
         assert len(collection_calls) > 0, "Videos collections completed event should be published"
     
     @pytest.mark.asyncio

--- a/services/video-crawler/tests/integration/test_tiktok_integration.py
+++ b/services/video-crawler/tests/integration/test_tiktok_integration.py
@@ -1,17 +1,17 @@
 """Integration tests for TikTok crawler functionality."""
-import pytest
-pytestmark = pytest.mark.integration
-import asyncio
-import os
-from typing import Dict, Any, List
-from unittest.mock import AsyncMock, MagicMock
 
-from services.service import VideoCrawlerService
-from platform_crawler.interface import PlatformCrawlerInterface
-from platform_crawler.tiktok.tiktok_crawler import TikTokCrawler
+import pytest
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
 from common_py.database import DatabaseManager
 from common_py.messaging import MessageBroker
 from config_loader import config
+from platform_crawler.tiktok.tiktok_crawler import TikTokCrawler
+from services.service import VideoCrawlerService
+
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
@@ -217,7 +217,7 @@ class TestTikTokIntegration:
         # Execute the search request (this will simulate API failure)
         try:
             await service.handle_videos_search_request(event_data)
-        except Exception as e:
+        except Exception:
             # If the API call fails, we still want to verify the error handling
             # The service should still complete the process by calling the zero videos handler
             pass

--- a/services/video-crawler/tests/integration/youtube/test_youtube_integration.py
+++ b/services/video-crawler/tests/integration/youtube/test_youtube_integration.py
@@ -1,18 +1,17 @@
-import pytest
-pytestmark = pytest.mark.integration
 import asyncio
 import logging
 import os
 import tempfile
-from datetime import datetime, timedelta
+
+import pytest
+
 from platform_crawler.youtube.youtube_crawler import YoutubeCrawler
+
+pytestmark = pytest.mark.integration
 
 @pytest.mark.asyncio
 async def test_real_video_download_integration():
     """Integration test that actually downloads real YouTube videos"""
-    import tempfile
-    import os
-    
     crawler = YoutubeCrawler()
     
     # Use a temporary directory for testing
@@ -89,10 +88,6 @@ async def test_real_video_download_integration():
 @pytest.mark.asyncio
 async def test_file_reuse_functionality():
     """Test that existing video files are reused instead of re-downloaded"""
-    import tempfile
-    import os
-    from pathlib import Path
-    
     crawler = YoutubeCrawler()
     
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/services/video-crawler/tests/unit/config_downloads/test_config_downloads.py
+++ b/services/video-crawler/tests/unit/config_downloads/test_config_downloads.py
@@ -1,17 +1,18 @@
-import pytest
-pytestmark = pytest.mark.unit
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
-import tempfile
 import os
+import tempfile
+
+import pytest
 
 # Import config first to test environment variable loading
 import sys
-import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config_loader import VideoCrawlerConfig
-config = VideoCrawlerConfig()
 from platform_crawler.youtube.youtube_crawler import YoutubeCrawler
+
+config = VideoCrawlerConfig()
+
+pytestmark = pytest.mark.unit
 
 class MockYoutubeDownloader:
     """Mock downloader for testing"""

--- a/services/video-crawler/tests/unit/keyframe_extraction/test_keyframe_extractor.py
+++ b/services/video-crawler/tests/unit/keyframe_extraction/test_keyframe_extractor.py
@@ -1,21 +1,22 @@
-"""
-Unit tests for LengthAdaptiveKeyframeExtractor class
-"""
-import pytest
-pytestmark = pytest.mark.unit
-import asyncio
-import tempfile
+"""Unit tests for LengthAdaptiveKeyframeExtractor class."""
+
 import shutil
+import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch, MagicMock
+
 import cv2
 import numpy as np
+import pytest
 
-from keyframe_extractor.length_adaptive_extractor import LengthAdaptiveKeyframeExtractor, KeyframeConfig
 from keyframe_extractor.abstract_extractor import AbstractKeyframeExtractor
 from keyframe_extractor.interface import KeyframeExtractorInterface
+from keyframe_extractor.length_adaptive_extractor import (
+    KeyframeConfig,
+    LengthAdaptiveKeyframeExtractor,
+)
 from models.video import VideoProperties
 
+pytestmark = pytest.mark.unit
 
 class TestLengthAdaptiveKeyframeExtractor:
     """Test class for LengthAdaptiveKeyframeExtractor"""
@@ -72,32 +73,6 @@ class TestLengthAdaptiveKeyframeExtractor:
         assert isinstance(extractor, KeyframeExtractorInterface)
         assert hasattr(extractor, 'extract_keyframes')
         assert hasattr(extractor, '_extract_frames_from_video')
-    
-    @pytest.fixture
-    def sample_video(self, temp_dir):
-        """Create a sample video file for testing"""
-        video_path = Path(temp_dir) / "test_video.mp4"
-        
-        # Create a simple test video using OpenCV
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-        fps = 30
-        frame_size = (640, 480)
-        
-        out = cv2.VideoWriter(str(video_path), fourcc, fps, frame_size)
-        
-        # Create 150 frames (5 seconds at 30fps)
-        for i in range(150):
-            # Create a frame with changing colors
-            frame = np.zeros((480, 640, 3), dtype=np.uint8)
-            # Change color over time
-            frame[:, :] = (i % 255, (i * 2) % 255, (i * 3) % 255)
-            # Add frame number text
-            cv2.putText(frame, f"Frame {i}", (50, 50), 
-                       cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
-            out.write(frame)
-        
-        out.release()
-        return str(video_path)
     
     @pytest.mark.asyncio
     async def test_extract_keyframes_without_video_file(self, extractor):

--- a/services/video-crawler/tests/unit/keyframe_extraction/test_length_adaptive_keyframe_extractor.py
+++ b/services/video-crawler/tests/unit/keyframe_extraction/test_length_adaptive_keyframe_extractor.py
@@ -1,20 +1,22 @@
-"""
-Unit tests for LengthAdaptiveKeyframeExtractor class
-"""
-import pytest
-pytestmark = pytest.mark.unit
-import asyncio
-import tempfile
+"""Unit tests for LengthAdaptiveKeyframeExtractor class."""
+
 import shutil
+import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch, MagicMock
+
 import cv2
 import numpy as np
+import pytest
 
-from keyframe_extractor.length_adaptive_extractor import LengthAdaptiveKeyframeExtractor, KeyframeConfig
 from keyframe_extractor.abstract_extractor import AbstractKeyframeExtractor
 from keyframe_extractor.interface import KeyframeExtractorInterface
+from keyframe_extractor.length_adaptive_extractor import (
+    KeyframeConfig,
+    LengthAdaptiveKeyframeExtractor,
+)
 from models.video import VideoProperties
+
+pytestmark = pytest.mark.unit
 
 
 class TestLengthAdaptiveKeyframeExtractor:
@@ -72,32 +74,6 @@ class TestLengthAdaptiveKeyframeExtractor:
         assert isinstance(extractor, KeyframeExtractorInterface)
         assert hasattr(extractor, 'extract_keyframes')
         assert hasattr(extractor, '_extract_frames_from_video')
-    
-    @pytest.fixture
-    def sample_video(self, temp_dir):
-        """Create a sample video file for testing"""
-        video_path = Path(temp_dir) / "test_video.mp4"
-        
-        # Create a simple test video using OpenCV
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-        fps = 30
-        frame_size = (640, 480)
-        
-        out = cv2.VideoWriter(str(video_path), fourcc, fps, frame_size)
-        
-        # Create 150 frames (5 seconds at 30fps)
-        for i in range(150):
-            # Create a frame with changing colors
-            frame = np.zeros((480, 640, 3), dtype=np.uint8)
-            # Change color over time
-            frame[:, :] = (i % 255, (i * 2) % 255, (i * 3) % 255)
-            # Add frame number text
-            cv2.putText(frame, f"Frame {i}", (50, 50), 
-                       cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
-            out.write(frame)
-        
-        out.release()
-        return str(video_path)
     
     @pytest.mark.asyncio
     async def test_extract_keyframes_without_video_file(self, extractor):

--- a/services/video-crawler/tests/unit/platform_queries/test_platform_queries.py
+++ b/services/video-crawler/tests/unit/platform_queries/test_platform_queries.py
@@ -1,7 +1,11 @@
 """Unit tests for platform-specific query extraction logic."""
+
 import pytest
-pytestmark = pytest.mark.unit
+
 from services.service import VideoCrawlerService
+
+
+pytestmark = pytest.mark.unit
 
 
 class TestPlatformQueryExtraction:

--- a/services/video-crawler/tests/unit/tiktok/test_tiktok_models.py
+++ b/services/video-crawler/tests/unit/tiktok/test_tiktok_models.py
@@ -1,7 +1,11 @@
 """Unit tests for TikTok data models."""
+
 import pytest
+
+from platform_crawler.tiktok.tiktok_models import TikTokSearchResponse, TikTokVideo
+
+
 pytestmark = pytest.mark.unit
-from platform_crawler.tiktok.tiktok_models import TikTokVideo, TikTokSearchResponse
 
 
 class TestTikTokVideo:

--- a/services/video-crawler/tests/unit/tiktok/test_tiktok_searcher.py
+++ b/services/video-crawler/tests/unit/tiktok/test_tiktok_searcher.py
@@ -1,10 +1,14 @@
 """Unit tests for TikTokSearcher HTTP client."""
-import pytest
-pytestmark = pytest.mark.unit
+
 import httpx
-from unittest.mock import AsyncMock, patch, MagicMock
-from platform_crawler.tiktok.tiktok_searcher import TikTokSearcher
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from platform_crawler.tiktok.tiktok_models import TikTokSearchResponse
+from platform_crawler.tiktok.tiktok_searcher import TikTokSearcher
+
+pytestmark = pytest.mark.unit
 
 
 class TestTikTokSearcher:

--- a/services/video-crawler/tests/unit/video_cleanup/test_video_cleanup_service.py
+++ b/services/video-crawler/tests/unit/video_cleanup/test_video_cleanup_service.py
@@ -1,17 +1,18 @@
-"""
-Unit tests for VideoCleanupService
-"""
+"""Unit tests for VideoCleanupService."""
 
-import pytest
-pytestmark = pytest.mark.unit
 import os
 import tempfile
 import unittest
-from unittest.mock import patch, MagicMock, AsyncMock
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from services.cleanup_service import VideoCleanupService
 from utils.file_cleanup import VideoCleanupManager
+
+
+pytestmark = pytest.mark.unit
 
 
 class TestVideoCleanupService(unittest.TestCase):
@@ -174,8 +175,11 @@ class TestVideoCleanupService(unittest.TestCase):
         mock_logger.info.assert_called()
         
         # Check for cleanup start log
-        cleanup_logs = [call for call in mock_logger.info.call_args_list 
-                       if any(x in call.args[0] for x in ['CLEANUP-START', 'CLEANUP-COMPLETE'])]
+        cleanup_logs = [
+            log_call
+            for log_call in mock_logger.info.call_args_list
+            if any(message in log_call.args[0] for message in ['CLEANUP-START', 'CLEANUP-COMPLETE'])
+        ]
         self.assertTrue(len(cleanup_logs) > 0, "Should log cleanup operations")
         
     @patch('services.cleanup_service.logger')
@@ -188,8 +192,11 @@ class TestVideoCleanupService(unittest.TestCase):
         mock_logger.info.assert_called()
         
         # Check for cleanup skipped log
-        skip_logs = [call for call in mock_logger.info.call_args_list 
-                    if 'CLEANUP-SKIPPED' in call.args[0]]
+        skip_logs = [
+            log_call
+            for log_call in mock_logger.info.call_args_list
+            if 'CLEANUP-SKIPPED' in log_call.args[0]
+        ]
         self.assertTrue(len(skip_logs) > 0, "Should log cleanup skipped")
         
     async def test_cleanup_error_handling(self):

--- a/services/video-crawler/tests/unit/youtube/test_cross_platform_parallelism.py
+++ b/services/video-crawler/tests/unit/youtube/test_cross_platform_parallelism.py
@@ -1,16 +1,16 @@
-import pytest
-pytestmark = pytest.mark.unit
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 import tempfile
-import os
-from pathlib import Path
 import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 # Import the classes we need to test
 from services.service import VideoCrawlerService
 from fetcher.video_fetcher import VideoFetcher
 from platform_crawler.interface import PlatformCrawlerInterface
+
+pytestmark = pytest.mark.unit
 
 class MockPlatformCrawler(PlatformCrawlerInterface):
     """Mock platform crawler for testing parallelism"""
@@ -28,8 +28,6 @@ class MockPlatformCrawler(PlatformCrawlerInterface):
         
         # Simulate processing delay
         await asyncio.sleep(self.delay_seconds)
-        
-        end_time = time.time()
         
         # Return mock videos
         return [

--- a/services/video-crawler/tests/unit/youtube/test_parallel_youtube_download.py
+++ b/services/video-crawler/tests/unit/youtube/test_parallel_youtube_download.py
@@ -1,13 +1,11 @@
-import pytest
-pytestmark = pytest.mark.unit
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 import tempfile
-import os
-from pathlib import Path
 
-# Import directly from the files we need to test
+import pytest
+
 from platform_crawler.youtube.youtube_crawler import YoutubeCrawler
+
+pytestmark = pytest.mark.unit
 
 class MockYoutubeDownloader:
     """Mock downloader for testing"""

--- a/services/video-crawler/tests/unit/youtube/test_youtube_crawler.py
+++ b/services/video-crawler/tests/unit/youtube/test_youtube_crawler.py
@@ -1,15 +1,12 @@
-import pytest
-pytestmark = pytest.mark.unit
-import os
 import tempfile
-import asyncio
-import re
-import logging
-from pathlib import Path
-from unittest.mock import patch, AsyncMock
-from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
 from platform_crawler.youtube.youtube_crawler import YoutubeCrawler
 from platform_crawler.youtube.youtube_utils import is_url_like, sanitize_filename
+
+pytestmark = pytest.mark.unit
 
 
 class TestYoutubeCrawler:
@@ -37,7 +34,7 @@ class TestYoutubeCrawler:
         ]
         
         for query in url_queries:
-            assert is_url_like(query) == True
+            assert is_url_like(query)
         
         # Valid keyword queries that should NOT be skipped
         keyword_queries = [
@@ -49,7 +46,7 @@ class TestYoutubeCrawler:
         ]
         
         for query in keyword_queries:
-            assert is_url_like(query) == False
+            assert not is_url_like(query)
     
     def test_sanitize_filename(self):
         """Test filename sanitization"""
@@ -96,10 +93,6 @@ class TestYoutubeCrawler:
         recency_days = 7
         download_dir = self.temp_dir
         num_videos = 3
-        
-        # Mock search results with different dates
-        old_date = datetime.utcnow() - timedelta(days=30)
-        recent_date = datetime.utcnow() - timedelta(days=3)
         
         mock_videos = [
             {

--- a/services/video-crawler/utils/file_cleanup.py
+++ b/services/video-crawler/utils/file_cleanup.py
@@ -5,7 +5,6 @@ Provides functionality to automatically remove old video files based on age.
 """
 
 import os
-import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Dict, Any, Optional

--- a/services/video-crawler/utils/filter_chain.py
+++ b/services/video-crawler/utils/filter_chain.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Any, Tuple, Dict
+from typing import List, Callable, Any, Tuple
 from datetime import datetime
 from common_py.logging_config import configure_logging
 


### PR DESCRIPTION
## Summary
- import `VideoProperties` safely in the abstract keyframe extractor so deferred type hints lint cleanly
- drop placeholder f-strings in the YouTube downloader/searcher and tidy redundant fixture definitions
- reorder imports and rename log-call loops across the video crawler tests to clear the remaining lint violations

## Testing
- PYENV_VERSION=3.10.17 ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d8eb6333cc8326aa031ad287df22e9