### PR TITLE
Fix asyncio loop usage in product segmentor service

### DIFF
--- a/services/product-segmentor/segmentation/models/rmbg14_segmentor.py
+++ b/services/product-segmentor/segmentation/models/rmbg14_segmentor.py
@@ -44,7 +44,7 @@ class RMBG14Segmentor(BaseSegmentation):
                 torch.set_float32_matmul_precision('high')
 
             # Load model in executor to avoid blocking
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             logger.info("Loading RMBG-1.4 model", model_name=self._model_name)
             # Load model
@@ -95,7 +95,7 @@ class RMBG14Segmentor(BaseSegmentation):
             raise FileNotFoundError(f"Image file not found: {image_path}")
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             image, input_tensor = await loop.run_in_executor(
                 None,
                 prepare_image,

--- a/services/product-segmentor/segmentation/models/rmbg20_segmentor.py
+++ b/services/product-segmentor/segmentation/models/rmbg20_segmentor.py
@@ -44,7 +44,7 @@ class RMBG20Segmentor(BaseSegmentation):
                 torch.set_float32_matmul_precision('high')
 
             # Load model in executor to avoid blocking
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             logger.info("Loading RMBG-2.0 model with trust_remote_code=True", model_name=self._model_name)
             # Load model
@@ -97,7 +97,7 @@ class RMBG20Segmentor(BaseSegmentation):
         try:
             logger.debug("Processing image for segmentation", path=image_path)
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             image, input_tensor = await loop.run_in_executor(
                 None,
                 prepare_image,

--- a/services/product-segmentor/tests/unit/services/test_concurrent_processing.py
+++ b/services/product-segmentor/tests/unit/services/test_concurrent_processing.py
@@ -156,9 +156,9 @@ class TestConcurrentProcessing:
                     tasks.append(task)
 
         # Start tasks and check that they don't all run at once
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         await asyncio.gather(*tasks)
-        end_time = asyncio.get_event_loop().time()
+        end_time = asyncio.get_running_loop().time()
 
         # With 10 tasks, 2 concurrent, and 0.2s delay each, minimum time should be around 1s
         # (5 batches of 2 tasks each)

--- a/services/product-segmentor/utils/file_manager.py
+++ b/services/product-segmentor/utils/file_manager.py
@@ -43,7 +43,7 @@ class FileManager:
             logger.info("Initializing mask directory structure", foreground_base_path=str(self.foreground_mask_base_path))
 
             # Create directories in executor to avoid blocking
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self._create_directories)
 
             logger.info("Mask directories created successfully")
@@ -111,7 +111,7 @@ class FileManager:
         # Create temporary file in the same directory as target
         temp_dir = target_path.parent
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         # Save to temporary file first
         with tempfile.NamedTemporaryFile(
@@ -183,7 +183,7 @@ class FileManager:
             True if mask file exists and is readable
         """
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 None,
                 lambda: os.path.isfile(mask_path) and os.access(mask_path, os.R_OK)
@@ -201,7 +201,7 @@ class FileManager:
             (width, height) tuple or None if file cannot be read
         """
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 None,
                 self._get_image_size,


### PR DESCRIPTION
## Summary
- replace deprecated asyncio.get_event_loop() calls in the product-segmentor service with asyncio.get_running_loop()
- update the concurrent processing unit test to use the running loop API for timing to stay consistent with production code

## Testing
- not run (missing python dependencies; pip install blocked by proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68da0508760483268cb539d2e96c75a2