### PR TITLE
Restrict YouTube and TikTok crawler queries to Vietnamese

### DIFF
--- a/services/video-crawler/services/service.py
+++ b/services/video-crawler/services/service.py
@@ -140,10 +140,11 @@ class VideoCrawlerService:
         if isinstance(queries, dict):
             platforms_lower = {platform.lower() for platform in platforms}
 
-            if platforms_lower == {"tiktok"}:
+            if {"tiktok", "youtube"} & platforms_lower:
                 prioritized = _normalize(queries.get("vi"))
                 if prioritized:
                     return prioritized
+                return []
 
             aggregated: List[str] = []
             for value in queries.values():

--- a/services/video-crawler/tests/unit/platform_queries/test_platform_queries.py
+++ b/services/video-crawler/tests/unit/platform_queries/test_platform_queries.py
@@ -38,7 +38,7 @@ class TestPlatformQueryExtraction:
         extracted = query_service._extract_platform_queries(queries, platforms)
 
         assert isinstance(extracted, list)
-        assert len(extracted) > 0
+        assert extracted == ["gối ergonomic", "pillow thoải mái"]
 
     def test_extract_platform_queries_multiple_platforms(self, query_service):
         """Test query extraction with multiple platforms including TikTok."""
@@ -51,7 +51,7 @@ class TestPlatformQueryExtraction:
         extracted = query_service._extract_platform_queries(queries, platforms)
 
         assert isinstance(extracted, list)
-        assert len(extracted) == 4
+        assert extracted == ["query vi 1", "query vi 2"]
 
     def test_extract_platform_queries_tiktok_only(self, query_service):
         """Test query extraction for TikTok platform only."""
@@ -68,6 +68,18 @@ class TestPlatformQueryExtraction:
         assert "đánh giá tai nghe không dây" in extracted
         assert "unbox iphone 15" in extracted
         assert "wireless earbuds review 2024" not in extracted
+
+    def test_extract_platform_queries_youtube_without_vietnamese(self, query_service):
+        """When Vietnamese queries are absent, YouTube should not fall back to other languages."""
+        queries = {
+            "zh": ["产品评测"],
+            "en": ["product review"]
+        }
+        platforms = ["youtube"]
+
+        extracted = query_service._extract_platform_queries(queries, platforms)
+
+        assert extracted == []
 
     def test_extract_platform_queries_invalid_input(self, query_service):
         """Test query extraction with invalid input formats."""


### PR DESCRIPTION
## Summary
- update the video crawler to prioritize Vietnamese queries when handling YouTube or TikTok requests and skip non-Vietnamese options
- adjust unit tests to expect Vietnamese-only queries and cover scenarios without Vietnamese inputs

## Testing
- ⚠️ `pip install -r requirements-test.txt` *(fails: proxy returns 403, preventing dependency installation)*
- ⚠️ `python -m pytest services/video-crawler/tests/unit/platform_queries/test_platform_queries.py -q` *(fails: pytest module unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68de350a41cc832688e87f4868df87c5