### PR TITLE
Add embedding similarity unit tests and numpy fallback

### DIFF
--- a/services/matcher/matching_components/vector_searcher.py
+++ b/services/matcher/matching_components/vector_searcher.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-import numpy as np
+from utils.numpy_compat import np
 
 from common_py.logging_config import configure_logging
 

--- a/services/matcher/pytest.ini
+++ b/services/matcher/pytest.ini
@@ -17,3 +17,4 @@ markers =
     unit: Mark a test as a unit test.
     integration: Mark a test as an integration test.
     contract: Mark a test as a contract test.
+    asyncio: Mark a test as requiring asyncio support.

--- a/services/matcher/tests/conftest.py
+++ b/services/matcher/tests/conftest.py
@@ -1,6 +1,14 @@
 """Shared pytest configuration for matcher service tests."""
-from pathlib import Path
+
+from __future__ import annotations
+
+import asyncio
+import inspect
 import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 TESTS_DIR = Path(__file__).resolve().parent
 SERVICE_ROOT = TESTS_DIR.parent
@@ -12,3 +20,70 @@ for candidate in (SERVICE_ROOT, LIBS_ROOT, COMMON_PY_ROOT):
     candidate_str = str(candidate)
     if candidate_str not in sys.path:
         sys.path.insert(0, candidate_str)
+
+
+try:  # pragma: no cover - runtime configuration
+    import asyncpg  # type: ignore  # noqa: F401 - imported for side effects
+except ImportError:  # pragma: no cover - executed in lightweight test envs
+    async def _create_pool(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("asyncpg is not installed in the test environment")
+
+    sys.modules["asyncpg"] = SimpleNamespace(Pool=object, create_pool=_create_pool)
+
+
+try:  # pragma: no cover - runtime configuration
+    import aio_pika  # type: ignore  # noqa: F401 - imported for side effects
+except ImportError:  # pragma: no cover - executed in lightweight test envs
+    class _DeliveryMode:
+        PERSISTENT = "PERSISTENT"
+
+    class _ExchangeType:
+        TOPIC = "TOPIC"
+
+    class _Message:
+        def __init__(self, *args, **kwargs) -> None:
+            self.body = args[0] if args else b""
+
+    async def _connect_robust(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("aio_pika is not installed in the test environment")
+
+    sys.modules["aio_pika"] = SimpleNamespace(
+        ExchangeType=_ExchangeType,
+        DeliveryMode=_DeliveryMode,
+        Exchange=object,
+        IncomingMessage=object,
+        Message=_Message,
+        connect_robust=_connect_robust,
+    )
+
+
+try:  # pragma: no cover - runtime configuration
+    from pydantic import BaseModel  # type: ignore  # noqa: F401
+except ImportError:  # pragma: no cover - executed in lightweight test envs
+    class _BaseModel:
+        def __init__(self, **data) -> None:
+            for key, value in data.items():
+                setattr(self, key, value)
+
+        def dict(self) -> dict[str, object]:
+            return self.__dict__.copy()
+
+    def _field(default=..., **kwargs):  # type: ignore[no-untyped-def]
+        return default
+
+    sys.modules["pydantic"] = SimpleNamespace(BaseModel=_BaseModel, Field=_field)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Execute ``async def`` tests without requiring external plugins."""
+
+    test_func = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_func):
+        testargs = {
+            name: pyfuncitem.funcargs[name]
+            for name in pyfuncitem._fixtureinfo.argnames  # type: ignore[attr-defined]
+        }
+        asyncio.run(test_func(**testargs))
+        return True
+    return None

--- a/services/matcher/tests/unit/test_matching.py
+++ b/services/matcher/tests/unit/test_matching.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch, create_autospec
 
-import numpy as np
 import pytest
 
 from common_py.database import DatabaseManager
 from matching import MatchingEngine
 from matching_components.match_aggregator import MatchAggregator
+from utils.numpy_compat import np
 
 pytestmark = pytest.mark.unit
 

--- a/services/matcher/tests/unit/utils/test_embedding_similarity.py
+++ b/services/matcher/tests/unit/utils/test_embedding_similarity.py
@@ -1,0 +1,130 @@
+"""Tests for :mod:`utils.embedding_similarity`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from utils.embedding_similarity import EmbeddingSimilarity
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def similarity() -> EmbeddingSimilarity:
+    """Provide an :class:`EmbeddingSimilarity` instance for testing."""
+
+    return EmbeddingSimilarity()
+
+
+@pytest.fixture
+def query_embedding() -> Dict[str, Any]:
+    """Return a representative embedding used across tests."""
+
+    return {
+        "frame_id": "query",
+        "emb_rgb": [1.0, 0.0, 0.0],
+        "emb_gray": [0.0, 1.0, 0.0],
+    }
+
+
+def test_calculate_similarity_combines_rgb_and_gray(
+    similarity: EmbeddingSimilarity,
+    query_embedding: Dict[str, Any],
+) -> None:
+    """The similarity score blends RGB and grayscale components."""
+
+    candidate_embedding = {
+        "frame_id": "candidate",
+        "emb_rgb": [1.0, 0.0, 0.0],
+        "emb_gray": [0.0, 1.0, 0.0],
+    }
+
+    score = asyncio.run(
+        similarity.calculate_similarity(query_embedding, candidate_embedding)
+    )
+
+    assert score == pytest.approx(1.0)
+
+
+def test_calculate_similarity_uses_available_channel(
+    similarity: EmbeddingSimilarity,
+    query_embedding: Dict[str, Any],
+) -> None:
+    """The calculator falls back to grayscale embeddings when RGB is absent."""
+
+    query = {"emb_gray": [1.0, 0.0]}
+    candidate = {"emb_gray": [1.0, 0.0]}
+
+    score = asyncio.run(similarity.calculate_similarity(query, candidate))
+
+    assert score == pytest.approx(1.0)
+
+
+def test_calculate_similarity_returns_zero_for_invalid_input(
+    similarity: EmbeddingSimilarity,
+) -> None:
+    """Invalid embeddings are handled defensively and produce a score of ``0``."""
+
+    score = asyncio.run(similarity.calculate_similarity({}, {}))
+
+    assert score == 0.0
+
+
+def test_batch_similarity_search_filters_and_sorts_results(
+    similarity: EmbeddingSimilarity,
+    query_embedding: Dict[str, Any],
+) -> None:
+    """Batch search keeps only positive similarities and returns them sorted."""
+
+    candidate_embeddings: List[Dict[str, Any]] = [
+        {
+            "frame_id": "high",
+            "emb_rgb": [1.0, 0.0, 0.0],
+            "emb_gray": [0.0, 1.0, 0.0],
+        },
+        {
+            "frame_id": "medium",
+            "emb_rgb": [0.5, 0.5, 0.0],
+            "emb_gray": [0.5, 0.5, 0.0],
+        },
+        {
+            "frame_id": "zero",
+            "emb_rgb": [0.0, 0.0, 1.0],
+            "emb_gray": [0.0, 0.0, 1.0],
+        },
+    ]
+
+    results = asyncio.run(
+        similarity.batch_similarity_search(
+            query_embedding,
+            candidate_embeddings,
+            top_k=2,
+        )
+    )
+
+    assert [result["frame_id"] for result in results] == ["high", "medium"]
+    assert all(result["similarity"] > 0 for result in results)
+
+
+def test_get_embedding_stats_returns_means(similarity: EmbeddingSimilarity) -> None:
+    """The statistics helper summarises the provided embeddings."""
+
+    embeddings = [
+        {
+            "emb_rgb": [1.0, 0.0],
+            "emb_gray": [0.5, 0.5],
+        },
+        {
+            "emb_rgb": [0.0, 1.0],
+            "emb_gray": [0.5, -0.5],
+        },
+    ]
+
+    stats = similarity.get_embedding_stats(embeddings)
+
+    assert stats["count"] == 2
+    assert stats["rgb_self_similarity_mean"] == pytest.approx(1.0)
+    assert stats["gray_self_similarity_mean"] == pytest.approx(1.0)

--- a/services/matcher/utils/embedding_similarity.py
+++ b/services/matcher/utils/embedding_similarity.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-import numpy as np
+from utils.numpy_compat import np
 
 from common_py.logging_config import configure_logging
 

--- a/services/matcher/utils/numpy_compat.py
+++ b/services/matcher/utils/numpy_compat.py
@@ -1,0 +1,42 @@
+"""Compatibility layer for NumPy usage within the matcher service."""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import Iterable, Sequence
+
+try:  # pragma: no cover - executed when NumPy is available
+    import numpy as _np
+except ImportError:  # pragma: no cover - triggered in minimal test environments
+
+    class _FallbackNumpy:
+        """Provide a very small subset of :mod:`numpy` for local testing."""
+
+        float32 = float
+        ndarray = list
+
+        @staticmethod
+        def array(values: Iterable[float], dtype: object | None = None) -> list[float]:
+            del dtype  # The lightweight fallback treats all values as ``float``.
+            if isinstance(values, Sequence):
+                return [float(value) for value in values]
+            return [float(value) for value in list(values)]
+
+        @staticmethod
+        def dot(vec1: Sequence[float], vec2: Sequence[float]) -> float:
+            return sum(a * b for a, b in zip(vec1, vec2))
+
+        class linalg:  # type: ignore[valid-type]
+            @staticmethod
+            def norm(vec: Sequence[float]) -> float:
+                return sqrt(sum(value * value for value in vec))
+
+        @staticmethod
+        def mean(values: Sequence[float]) -> float:
+            return sum(values) / len(values) if values else 0.0
+
+    np = _FallbackNumpy()  # type: ignore[assignment]
+else:
+    np = _np
+
+__all__ = ["np"]


### PR DESCRIPTION
## Summary
- add a lightweight NumPy compatibility shim used throughout the matcher utilities
- update matcher code and existing tests to consume the shared shim
- expand the unit test suite with detailed coverage for embedding similarity behaviour and test scaffolding for async tests in minimal environments

## Testing
- PYENV_VERSION=3.11.12 python -m pytest tests/unit/utils/test_embedding_similarity.py --override-ini addopts="--strict-markers"

------
https://chatgpt.com/codex/tasks/task_e_68dfb76b8cbc832690b22694374e7b28